### PR TITLE
Added prevent default while using sliders and pad in ColorPicker

### DIFF
--- a/src/ColorPicker/ColorPicker.js
+++ b/src/ColorPicker/ColorPicker.js
@@ -56,6 +56,7 @@ class ColorPicker extends React.PureComponent {
 	}
 
 	start(e) {
+		e.preventDefault();
 		this.props.onStart(_css(hsba_to_hsv(this.state)), e);
 	}
 

--- a/src/Pad/Pad.js
+++ b/src/Pad/Pad.js
@@ -112,6 +112,7 @@ class Pad extends React.PureComponent {
 	}
 
 	start(e) {
+		e.persist();
 		this.setState(
 			{
 				interacting: true

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -51,6 +51,7 @@ class Slider extends React.Component {
 	}
 
 	start(e) {
+		e.persist();
 		this.setState(
 			{
 				interacting: true


### PR DESCRIPTION
I don't know if `e.persist()` has any big perf impact but it is the only way to give access to async called events. In this case the event object is passed in a `setState()` callback and if you want to call methods on it it won't work.

